### PR TITLE
Automatic Chunk GC Feature

### DIFF
--- a/core/src/org/egordorichev/lasttry/Globals.java
+++ b/core/src/org/egordorichev/lasttry/Globals.java
@@ -5,6 +5,7 @@ import org.egordorichev.lasttry.entity.player.Player;
 import org.egordorichev.lasttry.entity.player.PlayerIO;
 import org.egordorichev.lasttry.world.World;
 import org.egordorichev.lasttry.world.WorldIO;
+import org.egordorichev.lasttry.world.chunk.gc.ChunkGcManager;
 import org.egordorichev.lasttry.world.environment.Environment;
 import org.egordorichev.lasttry.world.spawn.SpawnSystem;
 
@@ -14,6 +15,7 @@ public class Globals {
     public static Environment environment;
     public static SpawnSystem spawnSystem;
     public static EntityManager entityManager;
+    public static ChunkGcManager chunkGcManager;
 
     public static void dispose() {
         if(player != null){

--- a/core/src/org/egordorichev/lasttry/state/GamePlayState.java
+++ b/core/src/org/egordorichev/lasttry/state/GamePlayState.java
@@ -17,6 +17,7 @@ import org.egordorichev.lasttry.item.ItemHolder;
 import org.egordorichev.lasttry.item.Items;
 import org.egordorichev.lasttry.item.block.Block;
 import org.egordorichev.lasttry.util.Camera;
+import org.egordorichev.lasttry.world.chunk.gc.ChunkGcManager;
 
 public class GamePlayState implements State {
 	private final Texture hpTexture;
@@ -33,6 +34,9 @@ public class GamePlayState implements State {
         Globals.entityManager = new EntityManager();
 
         Globals.entityManager.spawn(Enemies.create("Green Slime"), spawnX, spawnY + 4);
+
+        //Begin the ChunkGC process
+        Globals.chunkGcManager = new ChunkGcManager();
     }
 
     @Override

--- a/core/src/org/egordorichev/lasttry/util/Util.java
+++ b/core/src/org/egordorichev/lasttry/util/Util.java
@@ -7,10 +7,7 @@ import com.badlogic.gdx.InputProcessor;
 import org.egordorichev.lasttry.LastTry;
 import org.egordorichev.lasttry.input.InputManager;
 import java.io.File;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public class Util {
 	public static float map(float value, float inMin, float inMax, float outMin, float outMax) {
@@ -47,6 +44,22 @@ public class Util {
 				callable.call();
 			};
 		});
+	}
+
+	public static void futureOneTimeRunInThread(Callable callable, long delay, TimeUnit timeUnit) {
+
+		ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
+
+		ScheduledFuture<?> scheduledFuture = scheduledExecutorService
+				.schedule(
+				new Runnable() {
+					@Override
+					public void run() {
+						callable.call();
+					}
+				}, delay, timeUnit)
+				;
+
 	}
 
 	public static boolean fileExists(String path) {

--- a/core/src/org/egordorichev/lasttry/world/World.java
+++ b/core/src/org/egordorichev/lasttry/world/World.java
@@ -52,6 +52,8 @@ public class World {
 		return this.name;
 	}
 
+	public short getMaxChunks() { return this.size.getMaxChunks(); }
+
 	// GridPoints
 	public boolean isInside(int x, int y) {
 		return (x >= 0 && x < this.getWidth() && y >= 0 && y < this.getHeight());
@@ -88,18 +90,20 @@ public class World {
 	}
 
 	public enum Size {
-		SMALL("Small", 4096, 1024),
-		MEDIUM("Medium", 6144, 2048),
-		LARGE("Large", 8192, 2304);
+		SMALL("Small", 4096, 1024, 64),
+		MEDIUM("Medium", 6144, 2048, 192),
+		LARGE("Large", 8192, 2304, 288);
 
 		private String name;
 		private short width;
 		private short height;
+		private short maxChunks;
 
-		Size(String name, int width, int height) {
+		Size(String name, int width, int height, int maxChunks) {
 			this.name = name;
 			this.width = (short) width;
 			this.height = (short) height;
+			this.maxChunks = (short) maxChunks;
 		}
 
 		@Override
@@ -114,5 +118,7 @@ public class World {
 		public short getHeight() {
 			return this.height;
 		}
+
+		public short getMaxChunks() { return this.maxChunks; }
 	}
 }

--- a/core/src/org/egordorichev/lasttry/world/World.java
+++ b/core/src/org/egordorichev/lasttry/world/World.java
@@ -3,6 +3,7 @@ package org.egordorichev.lasttry.world;
 import org.egordorichev.lasttry.item.Item;
 import org.egordorichev.lasttry.item.block.Block;
 import org.egordorichev.lasttry.util.Rectangle;
+import org.egordorichev.lasttry.world.chunk.Chunk;
 import org.egordorichev.lasttry.world.components.WorldBlocksComponent;
 import org.egordorichev.lasttry.world.components.WorldChunksComponent;
 import org.egordorichev.lasttry.world.components.WorldFlagsComponent;
@@ -52,8 +53,6 @@ public class World {
 		return this.name;
 	}
 
-	public short getMaxChunks() { return this.size.getMaxChunks(); }
-
 	// GridPoints
 	public boolean isInside(int x, int y) {
 		return (x >= 0 && x < this.getWidth() && y >= 0 && y < this.getHeight());
@@ -90,16 +89,16 @@ public class World {
 	}
 
 	public enum Size {
-		SMALL("Small", 4096, 1024, 64),
-		MEDIUM("Medium", 6144, 2048, 192),
-		LARGE("Large", 8192, 2304, 288);
+		SMALL("Small", 4096, 1024),//Small contains 64 chunks
+		MEDIUM("Medium", 6144, 2048), //Medium contains 192 chunks
+		LARGE("Large", 8192, 2304); //Large contains 288 chunks
 
 		private String name;
 		private short width;
 		private short height;
 		private short maxChunks;
 
-		Size(String name, int width, int height, int maxChunks) {
+		Size(String name, int width, int height) {
 			this.name = name;
 			this.width = (short) width;
 			this.height = (short) height;
@@ -119,6 +118,11 @@ public class World {
 			return this.height;
 		}
 
-		public short getMaxChunks() { return this.maxChunks; }
+		public short getMaxChunks() {
+
+			int maxChunks = (width/Chunk.SIZE)*(short)(height/ Chunk.SIZE);
+
+			return (short)maxChunks;
+		}
 	}
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/Chunk.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/Chunk.java
@@ -203,5 +203,7 @@ public class Chunk {
 		return (x >= 0 && x < SIZE && y >= 0 && y < SIZE);
 	}
 
+	public UUID getUniqueChunkId() { return this.uniqueChunkId; }
+
 	public LocalDateTime getLastAccessedTime() { return this.lastAccessedTime; }
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -17,6 +17,15 @@ public class ChunkGc {
         this.currentChunkGcLevel = levelToRunChunkGcAt;
     }
 
+    public void onWakeUp(){
+        if(currentChunkGcLevel== ChunkGcCalc.ChunkGCLevel.SLEEP){
+            Globals.chunkGcManager.scheduleChunkGc(currentChunkGcLevel);
+        }else{
+            this.performChunkGC();
+        }
+    }
+
+
     public void performChunkGC() {
 
         Log.debug("Received request to perform Chunk GC");

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -20,6 +20,7 @@ public class ChunkGc {
         this.currentChunkGcLevel = levelToRunChunkGcAt;
     }
 
+    //todo split into smaller methods
     public void performChunkGC() {
 
         Log.debug("Received request to perform Chunk GC");

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -10,8 +10,8 @@ import org.egordorichev.lasttry.util.Util;
  * Rules:
  * LoadedChunks must contain at least 2 chunks -- Current chunk and last loaded chunks.
  */
-//todo ChunkGC to be triggered using an adjustable timer or when loaded chunks is reaching max chunks
-public class ChunkGC {
+//todo ChunkGc to be triggered using an adjustable timer or when loaded chunks is reaching max chunks
+public class ChunkGc {
 
     private boolean isChunkGCInProcess = false;
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -1,50 +1,25 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 
-import org.egordorichev.lasttry.Globals;
-import org.egordorichev.lasttry.LastTry;
-import org.egordorichev.lasttry.util.Callable;
-import org.egordorichev.lasttry.util.Util;
-
 /**
  * Handles automatic removal of unused loaded chunks from game memory.
  * Rules:
  * LoadedChunks must contain at least 2 chunks -- Current chunk and last loaded chunks.
  */
-//todo ChunkGc to be triggered using an adjustable timer or when loaded chunks is reaching max chunks
 public class ChunkGc {
 
-    private boolean isChunkGCInProcess = false;
+    private ChunkGcCalc.ChunkGCLevel currentChunkGcLevel;
 
-    //todo Chunk gc will be either triggered by: timer or when loaded chunks is approaching max chunks
-    public void requestChunkGC(){
-        int amountOfLoadedChunks = Globals.world.chunks.getAmountOfLoadedChunks();
-
-        if(amountOfLoadedChunks>2){
-            this.triggerChunkGC();
-        }else{
-            //todo increase the amount of time before next chunk gc request is sent.
-        }
+    ChunkGc(ChunkGcCalc.ChunkGCLevel levelToRunChunkGcAt) {
+        this.currentChunkGcLevel = levelToRunChunkGcAt;
     }
 
-    private synchronized void setChunkGCInProcess(boolean flag) { this.isChunkGCInProcess = flag; }
+    public void performChunkGC() {
 
-    private void triggerChunkGC() {
+        //todo set flag in chunk gc manager to true, signalling a chunk gc is in progress
 
-        this.setChunkGCInProcess(true);
+        //todo once complete set a flag in chunk gc manager, signalling a chunk gc is no longer in progress
 
-        Util.oneTimeRunInThread(new Callable() {
-            @Override
-            public void call() {
-                performChunkGC();
-            }
-        });
-
+        //todo once complete, call method in chunk gc manager to schedule next gc
     }
-
-    private void performChunkGC() {
-
-    }
-
-
 
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -46,7 +46,7 @@ public class ChunkGc {
         Log.debug("Amount of loaded chunks to free is: "+amountOfChunksToFree);
 
         ArrayList<UUID> uniqueIdsOfChunksToBeFreed = new ArrayList<>();
-        
+
         //We remove the oldest chunk, which will be the first chunks.
         for(int i=0; i<amountOfChunksToFree; i++){
             Chunk chunkToBeFreed = loadedChunks.get(i);

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -1,5 +1,8 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 
+import org.egordorichev.lasttry.LastTry;
+import org.egordorichev.lasttry.util.Log;
+
 /**
  * Handles automatic removal of unused loaded chunks from game memory.
  * Rules:
@@ -14,6 +17,8 @@ public class ChunkGc {
     }
 
     public void performChunkGC() {
+
+        Log.debug("Received request to perform Chunk GC");
 
         //todo set flag in chunk gc manager to true, signalling a chunk gc is in progress
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -1,13 +1,17 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 
+import org.egordorichev.lasttry.Globals;
 import org.egordorichev.lasttry.LastTry;
 import org.egordorichev.lasttry.util.Log;
+import org.egordorichev.lasttry.world.chunk.Chunk;
 
-/**
- * Handles automatic removal of unused loaded chunks from game memory.
- * Rules:
- * LoadedChunks must contain at least 2 chunks -- Current chunk and last loaded chunks.
- */
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.UUID;
+
+//Logic responsible for carrying out chunk gc
 public class ChunkGc {
 
     private ChunkGcCalc.ChunkGCLevel currentChunkGcLevel;
@@ -20,11 +24,41 @@ public class ChunkGc {
 
         Log.debug("Received request to perform Chunk GC");
 
-        //todo set flag in chunk gc manager to true, signalling a chunk gc is in progress
+        assert Globals.world.chunks.getAmountOfLoadedChunks()<=ChunkGcCalc.MINIMUMLOADEDCHUNKS : "Chunks currently loaded is less than or equal to minimum loaded chunks";
 
-        //todo once complete set a flag in chunk gc manager, signalling a chunk gc is no longer in progress
+        //Set flag in gc manager, signalling a chunk gc is in progress
+        Globals.chunkGcManager.setChunkGcInProgress(true);
 
-        //todo once complete, call method in chunk gc manager to schedule next gc
+        ArrayList<Chunk> loadedChunks = Globals.world.chunks.getLoadedChunks();
+        Log.debug("Amount of loaded chunks is: "+loadedChunks.size());
+
+        // Sort by local date, most recent date is last and oldest date is first.
+        Collections.sort(loadedChunks, new Comparator<Chunk>() {
+            public int compare(Chunk one, Chunk other) {
+                return one.getLastAccessedTime().compareTo(other.getLastAccessedTime());
+            }
+        });
+
+        int amountOfChunksToFree = currentChunkGcLevel.getChunksToFree();
+        Log.debug("Amount of loaded chunks to free is: "+amountOfChunksToFree);
+
+        ArrayList<UUID> uniqueIdsOfChunksToBeFreed = new ArrayList<>();
+
+        //We remove the oldest chunk, which will be the first chunks.
+        for(int i=0; i<amountOfChunksToFree; i++){
+            Chunk chunkToBeFreed = loadedChunks.get(i);
+            uniqueIdsOfChunksToBeFreed.add(chunkToBeFreed.getUniqueChunkId());
+        }
+
+        //free chunks
+        uniqueIdsOfChunksToBeFreed.stream().forEach(uniqueIdOfChunkToBeFreed -> {
+            Globals.world.chunks.removeChunk(uniqueIdOfChunkToBeFreed);
+        });
+
+        Globals.chunkGcManager.setChunkGcInProgress(false);
+
+        //Schedule next chunk gc
+        Globals.chunkGcManager.requestFutureChunkGc();
     }
 
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGc.java
@@ -6,10 +6,7 @@ import org.egordorichev.lasttry.util.Log;
 import org.egordorichev.lasttry.world.chunk.Chunk;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.UUID;
+import java.util.*;
 
 //Logic responsible for carrying out chunk gc
 public class ChunkGc {
@@ -25,12 +22,12 @@ public class ChunkGc {
 
         Log.debug("Received request to perform Chunk GC");
 
-        assert Globals.world.chunks.getAmountOfLoadedChunks()<=ChunkGcCalc.MINIMUMLOADEDCHUNKS : "Chunks currently loaded is less than or equal to minimum loaded chunks";
+        assert Globals.world.chunks.getImmutableLoadedChunks().size()<=ChunkGcCalc.MINIMUMLOADEDCHUNKS : "Chunks currently loaded is less than or equal to minimum loaded chunks";
 
         //Set flag in gc manager, signalling a chunk gc is in progress
         Globals.chunkGcManager.setChunkGcInProgress(true);
 
-        ArrayList<Chunk> loadedChunks = Globals.world.chunks.getLoadedChunks();
+        List<Chunk> loadedChunks = Globals.world.chunks.getImmutableLoadedChunks();
         Log.debug("Amount of loaded chunks is: "+loadedChunks.size());
 
         // Sort by local date, most recent date is last and oldest date is first.

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -62,7 +62,12 @@ public class ChunkGcCalc {
             return S6;
         }
 
+        return getAppropriateLevel(filledPercentOfChunks);
 
+    }
+
+    private static synchronized ChunkGCLevel getAppropriateLevel(int filledPercentOfChunks) {
+        
         ChunkGCLevel[] availGcLevels = ChunkGCLevel.values();
 
         ChunkGCLevel appropriateLevel = null;
@@ -80,6 +85,7 @@ public class ChunkGcCalc {
 
         return appropriateLevel;
     }
+
 
     //Calculates percentage of chunks that are filled out of max chunks for world
     private static int getFilledChunksPercent() {

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -96,7 +96,7 @@ public class ChunkGcCalc {
     private static int getFilledChunksPercent() {
         double maxChunksSize = Globals.world.getSize().getMaxChunks();
 
-        double loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
+        double loadedChunksSize = Globals.world.chunks.getImmutableLoadedChunks().size();
 
         if(loadedChunksSize<=MINIMUMLOADEDCHUNKS){
             return 0;

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -67,7 +67,7 @@ public class ChunkGcCalc {
     }
 
     private static synchronized ChunkGCLevel getAppropriateLevel(int filledPercentOfChunks) {
-        
+
         ChunkGCLevel[] availGcLevels = ChunkGCLevel.values();
 
         ChunkGCLevel appropriateLevel = null;

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -94,7 +94,7 @@ public class ChunkGcCalc {
 
     //Calculates percentage of chunks that are filled out of max chunks for world
     private static int getFilledChunksPercent() {
-        double maxChunksSize = Globals.world.getMaxChunks();
+        double maxChunksSize = Globals.world.getSize().getMaxChunks();
 
         double loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -1,0 +1,87 @@
+package org.egordorichev.lasttry.world.chunk.gc;
+
+import org.egordorichev.lasttry.Globals;
+
+//Static methods responsible for calculating the appropriate Chunk gc level
+public class ChunkGcCalc {
+
+    //Enums representing the 6 possible levels of a Chunk GC
+    public enum ChunkGCLevel{
+
+        S6("Level 6 - 15 sec interval, 5 chunk release", 90, 100, 15, 5),
+        S5("Level 5 - 20 sec interval, 6 chunk release", 80, 90, 20, 6),
+        S4("Level 4 - 30 sec interval, 10 chunk release", 75, 80, 30, 10),
+        S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
+        S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
+        S1("Level 1 - 120 sec interval, 5 chunk release", 10, 25, 120, 5);
+
+        private String levelDescription;
+        //Time Interval before the next GC process should be attempted again
+        private int timeIntervalBeforeNextAttempt;
+        private int chunksToFree;
+        private int triggerPercentageHigherBounds;
+        private int triggerPercentageLowerBounds;
+
+        ChunkGCLevel(String levelDescription, int triggerPercentageLowerBounds, int triggerPercentageHigherBounds, int timeIntervalBeforeNextAttempt, int chunksToFree) {
+            this.levelDescription = levelDescription;
+            this.triggerPercentageHigherBounds = triggerPercentageHigherBounds;
+            this.triggerPercentageLowerBounds = triggerPercentageLowerBounds;
+            this.timeIntervalBeforeNextAttempt = timeIntervalBeforeNextAttempt;
+            this.chunksToFree = chunksToFree;
+        }
+
+        public String getLevelDescription() {
+            return this.levelDescription;
+        }
+
+        public int getTimeIntervalBeforeNextAttempt() {
+            return this.timeIntervalBeforeNextAttempt;
+        }
+
+        public int getChunksToFree() {
+            return this.chunksToFree;
+        }
+
+        public int getTriggerPercentageHigherBounds() {
+            return this.triggerPercentageHigherBounds;
+        }
+
+        public int getTriggerPercentageLowerBounds() {
+            return this.triggerPercentageLowerBounds;
+        }
+    }
+
+    //Returns appropriate chunk gc level based on amount of loaded chunks in memory
+    public static ChunkGCLevel calcGcLevel(int currentlyLoadedChunks) {
+
+        int filledPercentOfChunks = getFilledChunksPercent();
+
+        ChunkGCLevel[] availGcLevels = ChunkGCLevel.values();
+
+        ChunkGCLevel appropriateLevel = null;
+
+        for(ChunkGCLevel chunkGCLevel: availGcLevels)
+        {
+            int higherBoundTriggerPercent = chunkGCLevel.getTriggerPercentageHigherBounds();
+            int lowerBoundTriggerPercent = chunkGCLevel.getTriggerPercentageLowerBounds();
+
+            if(filledPercentOfChunks<higherBoundTriggerPercent&&filledPercentOfChunks>lowerBoundTriggerPercent){
+                appropriateLevel = chunkGCLevel;
+            }
+        }
+
+        return appropriateLevel;
+    }
+
+    //Calculates percentage of chunks that are filled out of max chunks for world
+    private static int getFilledChunksPercent() {
+        int maxChunksSize = Globals.world.getMaxChunks();
+
+        int loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
+
+        int percentOfChunksLoaded = loadedChunksSize/maxChunksSize * 100;
+
+        return percentOfChunksLoaded;
+    }
+
+}

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -7,7 +7,7 @@ import static org.egordorichev.lasttry.world.chunk.gc.ChunkGcCalc.ChunkGCLevel.S
 //Static methods responsible for calculating the appropriate Chunk gc level
 public class ChunkGcCalc {
 
-    private final static int MINIMUMCHUNKS = 2;
+    public final static int MINIMUMLOADEDCHUNKS = 2;
 
     //Enums representing the 6 possible levels of a Chunk GC
     public enum ChunkGCLevel{
@@ -18,9 +18,9 @@ public class ChunkGcCalc {
         S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
         S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
         S1("Level 1 - 120 sec interval, 5 chunk release", 15, 25, 120, 5),
-        S0("Level 0 - 120 sec interval, 1 chunk release", 5, 15, 4, 1),
+        S0("Level 0 - 120 sec interval, 1 chunk release", 5, 15, 120, 1),
         //Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive
-        SLEEP("Sleep - 120 sec interval, 0 chunk release", 0, 5, 3, 0);
+        SLEEP("Sleep - 120 sec interval, 0 chunk release", 0, 5, 120, 0);
 
         private String levelDescription;
         //Time Interval before the next GC process should be attempted again
@@ -98,7 +98,7 @@ public class ChunkGcCalc {
 
         double loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
 
-        if(loadedChunksSize<=MINIMUMCHUNKS){
+        if(loadedChunksSize<=MINIMUMLOADEDCHUNKS){
             return 0;
         }
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -2,6 +2,8 @@ package org.egordorichev.lasttry.world.chunk.gc;
 
 import org.egordorichev.lasttry.Globals;
 
+import static org.egordorichev.lasttry.world.chunk.gc.ChunkGcCalc.ChunkGCLevel.S6;
+
 //Static methods responsible for calculating the appropriate Chunk gc level
 public class ChunkGcCalc {
 
@@ -13,7 +15,7 @@ public class ChunkGcCalc {
         S4("Level 4 - 30 sec interval, 10 chunk release", 75, 80, 30, 10),
         S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
         S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
-        S1("Level 1 - 120 sec interval, 5 chunk release", 10, 25, 120, 5);
+        S1("Level 1 - 120 sec interval, 5 chunk release", 0, 25, 120, 5);
 
         private String levelDescription;
         //Time Interval before the next GC process should be attempted again
@@ -56,6 +58,17 @@ public class ChunkGcCalc {
 
         int filledPercentOfChunks = getFilledChunksPercent();
 
+        //todo rethink this, must be a better exception to throw
+        if(filledPercentOfChunks>100){
+            throw new IllegalArgumentException("Filled percentage of chunks, is greater than 100");
+        }
+
+        //When percentage of chunks is full, immediately return S6;
+        if(filledPercentOfChunks==100){
+            return S6;
+        }
+
+
         ChunkGCLevel[] availGcLevels = ChunkGCLevel.values();
 
         ChunkGCLevel appropriateLevel = null;
@@ -65,7 +78,8 @@ public class ChunkGcCalc {
             int higherBoundTriggerPercent = chunkGCLevel.getTriggerPercentageHigherBounds();
             int lowerBoundTriggerPercent = chunkGCLevel.getTriggerPercentageLowerBounds();
 
-            if(filledPercentOfChunks<higherBoundTriggerPercent&&filledPercentOfChunks>lowerBoundTriggerPercent){
+            //todo right now if percentage of chunks is 100, it is not caught here but caught higher up
+            if(filledPercentOfChunks<higherBoundTriggerPercent&&filledPercentOfChunks>=lowerBoundTriggerPercent){
                 appropriateLevel = chunkGCLevel;
             }
         }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -7,6 +7,8 @@ import static org.egordorichev.lasttry.world.chunk.gc.ChunkGcCalc.ChunkGCLevel.S
 //Static methods responsible for calculating the appropriate Chunk gc level
 public class ChunkGcCalc {
 
+    private final static int MINIMUMCHUNKS = 2;
+
     //Enums representing the 6 possible levels of a Chunk GC
     public enum ChunkGCLevel{
 
@@ -15,7 +17,8 @@ public class ChunkGcCalc {
         S4("Level 4 - 30 sec interval, 10 chunk release", 75, 80, 30, 10),
         S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
         S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
-        S1("Level 1 - 120 sec interval, 5 chunk release", 0, 25, 120, 5);
+        S1("Level 1 - 120 sec interval, 5 chunk release", 15, 25, 120, 5),
+        SLEEP("Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive", 0, 15, 120, 0);
 
         private String levelDescription;
         //Time Interval before the next GC process should be attempted again

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -12,33 +12,29 @@ public class ChunkGcCalc {
     //Enums representing the 6 possible levels of a Chunk GC
     public enum ChunkGCLevel{
 
-        S6("Level 6 - 15 sec interval, 5 chunk release", 90, 100, 15, 5),
-        S5("Level 5 - 20 sec interval, 6 chunk release", 80, 90, 20, 6),
-        S4("Level 4 - 30 sec interval, 10 chunk release", 75, 80, 30, 10),
-        S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
-        S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
-        S1("Level 1 - 120 sec interval, 5 chunk release", 15, 25, 120, 5),
-        S0("Level 0 - 120 sec interval, 1 chunk release", 5, 15, 120, 1),
+        S6(ChunkGcLevel.ChunkGcLevelBounds.S6, 15, 5),
+        S5(ChunkGcLevel.ChunkGcLevelBounds.S5, 20, 6),
+        S4(ChunkGcLevel.ChunkGcLevelBounds.S4, 30, 10),
+        S3(ChunkGcLevel.ChunkGcLevelBounds.S3, 60, 10),
+        S2(ChunkGcLevel.ChunkGcLevelBounds.S2, 90, 5),
+        S1(ChunkGcLevel.ChunkGcLevelBounds.S1, 120, 5),
+        S0(ChunkGcLevel.ChunkGcLevelBounds.S0, 120, 1),
         //Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive
-        SLEEP("Sleep - 120 sec interval, 0 chunk release", 0, 5, 120, 0);
+        SLEEP(ChunkGcLevel.ChunkGcLevelBounds.SLEEP, 120, 0);
 
-        private String levelDescription;
+        private ChunkGcLevel.ChunkGcLevelBounds  chunkGcLevelDesc;
         //Time Interval before the next GC process should be attempted again
         private int timeIntervalBeforeNextAttempt;
         private int chunksToFree;
-        private int triggerPercentageHigherBounds;
-        private int triggerPercentageLowerBounds;
 
-        ChunkGCLevel(String levelDescription, int triggerPercentageLowerBounds, int triggerPercentageHigherBounds, int timeIntervalBeforeNextAttempt, int chunksToFree) {
-            this.levelDescription = levelDescription;
-            this.triggerPercentageHigherBounds = triggerPercentageHigherBounds;
-            this.triggerPercentageLowerBounds = triggerPercentageLowerBounds;
+        ChunkGCLevel(ChunkGcLevel.ChunkGcLevelBounds chunkDesc, int timeIntervalBeforeNextAttempt, int chunksToFree) {
+            this.chunkGcLevelDesc = chunkDesc;
             this.timeIntervalBeforeNextAttempt = timeIntervalBeforeNextAttempt;
             this.chunksToFree = chunksToFree;
         }
 
-        public String getLevelDescription() {
-            return this.levelDescription;
+        public ChunkGcLevel.ChunkGcLevelBounds getLevelDescription() {
+            return this.chunkGcLevelDesc;
         }
 
         public int getTimeIntervalBeforeNextAttempt() {
@@ -49,13 +45,6 @@ public class ChunkGcCalc {
             return this.chunksToFree;
         }
 
-        public int getTriggerPercentageHigherBounds() {
-            return this.triggerPercentageHigherBounds;
-        }
-
-        public int getTriggerPercentageLowerBounds() {
-            return this.triggerPercentageLowerBounds;
-        }
     }
 
     //Returns appropriate chunk gc level based on amount of loaded chunks in memory
@@ -80,8 +69,8 @@ public class ChunkGcCalc {
 
         for(ChunkGCLevel chunkGCLevel: availGcLevels)
         {
-            int higherBoundTriggerPercent = chunkGCLevel.getTriggerPercentageHigherBounds();
-            int lowerBoundTriggerPercent = chunkGCLevel.getTriggerPercentageLowerBounds();
+            int higherBoundTriggerPercent = chunkGCLevel.getLevelDescription().getTriggerPercentageHigherBounds();
+            int lowerBoundTriggerPercent = chunkGCLevel.getLevelDescription().getTriggerPercentageLowerBounds();
 
             //todo right now if percentage of chunks is 100, it is not caught here but caught higher up
             if(filledPercentOfChunks<higherBoundTriggerPercent&&filledPercentOfChunks>=lowerBoundTriggerPercent){

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -12,28 +12,28 @@ public class ChunkGcCalc {
     //Enums representing the 6 possible levels of a Chunk GC
     public enum ChunkGCLevel{
 
-        S6(ChunkGcLevel.ChunkGcLevelBounds.S6, 15, 5),
-        S5(ChunkGcLevel.ChunkGcLevelBounds.S5, 20, 6),
-        S4(ChunkGcLevel.ChunkGcLevelBounds.S4, 30, 10),
-        S3(ChunkGcLevel.ChunkGcLevelBounds.S3, 60, 10),
-        S2(ChunkGcLevel.ChunkGcLevelBounds.S2, 90, 5),
-        S1(ChunkGcLevel.ChunkGcLevelBounds.S1, 120, 5),
-        S0(ChunkGcLevel.ChunkGcLevelBounds.S0, 120, 1),
+        S6(ChunkGcLevelConstants.ChunkGcLevelBounds.S6, 15, 5),
+        S5(ChunkGcLevelConstants.ChunkGcLevelBounds.S5, 20, 6),
+        S4(ChunkGcLevelConstants.ChunkGcLevelBounds.S4, 30, 10),
+        S3(ChunkGcLevelConstants.ChunkGcLevelBounds.S3, 60, 10),
+        S2(ChunkGcLevelConstants.ChunkGcLevelBounds.S2, 90, 5),
+        S1(ChunkGcLevelConstants.ChunkGcLevelBounds.S1, 120, 5),
+        S0(ChunkGcLevelConstants.ChunkGcLevelBounds.S0, 120, 1),
         //Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive
-        SLEEP(ChunkGcLevel.ChunkGcLevelBounds.SLEEP, 120, 0);
+        SLEEP(ChunkGcLevelConstants.ChunkGcLevelBounds.SLEEP, 120, 0);
 
-        private ChunkGcLevel.ChunkGcLevelBounds  chunkGcLevelDesc;
+        private ChunkGcLevelConstants.ChunkGcLevelBounds  chunkGcLevelDesc;
         //Time Interval before the next GC process should be attempted again
         private int timeIntervalBeforeNextAttempt;
         private int chunksToFree;
 
-        ChunkGCLevel(ChunkGcLevel.ChunkGcLevelBounds chunkDesc, int timeIntervalBeforeNextAttempt, int chunksToFree) {
+        ChunkGCLevel(ChunkGcLevelConstants.ChunkGcLevelBounds chunkDesc, int timeIntervalBeforeNextAttempt, int chunksToFree) {
             this.chunkGcLevelDesc = chunkDesc;
             this.timeIntervalBeforeNextAttempt = timeIntervalBeforeNextAttempt;
             this.chunksToFree = chunksToFree;
         }
 
-        public ChunkGcLevel.ChunkGcLevelBounds getLevelDescription() {
+        public ChunkGcLevelConstants.ChunkGcLevelBounds getLevelDescription() {
             return this.chunkGcLevelDesc;
         }
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcCalc.java
@@ -18,7 +18,9 @@ public class ChunkGcCalc {
         S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75, 60, 10),
         S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50, 90, 5),
         S1("Level 1 - 120 sec interval, 5 chunk release", 15, 25, 120, 5),
-        SLEEP("Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive", 0, 15, 120, 0);
+        S0("Level 0 - 120 sec interval, 1 chunk release", 5, 15, 4, 1),
+        //Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive
+        SLEEP("Sleep - 120 sec interval, 0 chunk release", 0, 5, 3, 0);
 
         private String levelDescription;
         //Time Interval before the next GC process should be attempted again
@@ -57,7 +59,7 @@ public class ChunkGcCalc {
     }
 
     //Returns appropriate chunk gc level based on amount of loaded chunks in memory
-    public static ChunkGCLevel calcGcLevel(int currentlyLoadedChunks) {
+    public static synchronized ChunkGCLevel calcGcLevel(int currentlyLoadedChunks) {
 
         int filledPercentOfChunks = getFilledChunksPercent();
 
@@ -92,13 +94,19 @@ public class ChunkGcCalc {
 
     //Calculates percentage of chunks that are filled out of max chunks for world
     private static int getFilledChunksPercent() {
-        int maxChunksSize = Globals.world.getMaxChunks();
+        double maxChunksSize = Globals.world.getMaxChunks();
 
-        int loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
+        double loadedChunksSize = Globals.world.chunks.getAmountOfLoadedChunks();
 
-        int percentOfChunksLoaded = loadedChunksSize/maxChunksSize * 100;
+        if(loadedChunksSize<=MINIMUMCHUNKS){
+            return 0;
+        }
 
-        return percentOfChunksLoaded;
+        double loadedChunksOfTotalFraction = loadedChunksSize/maxChunksSize;
+
+        double loadedChunksOfTotalPercentage = loadedChunksOfTotalFraction * 100;
+
+        return (int)loadedChunksOfTotalPercentage;
     }
 
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcLevel.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcLevel.java
@@ -1,0 +1,47 @@
+package org.egordorichev.lasttry.world.chunk.gc;
+
+/**
+ * Created by Admin on 06/05/2017.
+ */
+public class ChunkGcLevel {
+
+    public enum ChunkGcLevelBounds{
+        S6("Level 6 - 15 sec interval, 5 chunk release", 90, 100),
+        S5("Level 5 - 20 sec interval, 6 chunk release", 80, 90),
+        S4("Level 4 - 30 sec interval, 10 chunk release", 75, 80),
+        S3("Level 3 - 60 sec interval, 10 chunk release", 50, 75),
+        S2("Level 2 - 90 sec interval, 5 chunk release", 25, 50),
+        S1("Level 1 - 120 sec interval, 5 chunk release", 15, 25),
+        S0("Level 0 - 120 sec interval, 1 chunk release", 5, 15),
+        //Amount of Chunks not enough for Chunks GC, Chunk GC will be inactive
+        SLEEP("Sleep - 120 sec interval, 0 chunk release", 0, 5);
+
+        private String levelDescription;
+        //Time Interval before the next GC process should be attempted again
+        private int triggerPercentageHigherBounds;
+        private int triggerPercentageLowerBounds;
+
+        ChunkGcLevelBounds(String levelDescription, int triggerPercentageLowerBounds, int triggerPercentageHigherBounds) {
+            this.levelDescription = levelDescription;
+            this.triggerPercentageHigherBounds = triggerPercentageHigherBounds;
+            this.triggerPercentageLowerBounds = triggerPercentageLowerBounds;
+
+        }
+
+        public String getLevelDescription() {
+            return this.levelDescription;
+        }
+
+        public int getTriggerPercentageHigherBounds() {
+            return this.triggerPercentageHigherBounds;
+        }
+
+        public int getTriggerPercentageLowerBounds() {
+            return this.triggerPercentageLowerBounds;
+        }
+
+    }
+
+
+
+}

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcLevelConstants.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcLevelConstants.java
@@ -1,9 +1,6 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 
-/**
- * Created by Admin on 06/05/2017.
- */
-public class ChunkGcLevel {
+public class ChunkGcLevelConstants {
 
     public enum ChunkGcLevelBounds{
         S6("Level 6 - 15 sec interval, 5 chunk release", 90, 100),

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -47,7 +47,7 @@ public class ChunkGcManager {
 
     private synchronized int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getImmutableLoadedChunks().size(); }
 
-    private synchronized void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
+    public synchronized void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
 
         Log.debug("Level of chunk gc to be scheduled is: "+chunkGCLevel.getLevelDescription());
 
@@ -62,15 +62,9 @@ public class ChunkGcManager {
                 //On wakeup, we run a chunk gc immediately based on a ChunkGC level we receive based on the current loaded chunks level
                 ChunkGcCalc.ChunkGCLevel chunkGCLevelForCurrentGc = ChunkGcCalc.calcGcLevel(Globals.world.chunks.getImmutableLoadedChunks().size());
 
-                //If the ChunkGcLevel is sleep, we set a delay for the amount of time and simply request another chunkgc on wakeup
-                if(chunkGCLevelForCurrentGc== ChunkGcCalc.ChunkGCLevel.SLEEP){
-                    Log.debug("Chunk GC level is sleep");
-                    Globals.chunkGcManager.scheduleChunkGc(chunkGCLevelForCurrentGc);
-                }else{
-                    ChunkGc chunkGcThread = new ChunkGc(chunkGCLevelForCurrentGc);
-                    Log.debug("Chunk GC level is: "+chunkGCLevelForCurrentGc.getLevelDescription());
-                    chunkGcThread.performChunkGC();
-                }
+                ChunkGc chunkGcThread = new ChunkGc(chunkGCLevelForCurrentGc);
+                chunkGcThread.onWakeUp();
+                
             }
         }, futureTimeSecondsToRunChunkGc, TimeUnit.SECONDS);
     }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -1,6 +1,8 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 import org.egordorichev.lasttry.Globals;
+import org.egordorichev.lasttry.LastTry;
 import org.egordorichev.lasttry.util.Callable;
+import org.egordorichev.lasttry.util.Log;
 import org.egordorichev.lasttry.util.Util;
 
 import java.util.concurrent.TimeUnit;
@@ -9,11 +11,13 @@ import java.util.concurrent.TimeUnit;
  * Responsible for determining intervals between Chunk GC should be run and amount of chunks to be freed.
  *
  */
+//todo re-evaluate synchronized methods
+//todo on first run, interval should be set to 10 seconds to allow game to load previous chunks?
 public class ChunkGcManager {
 
     boolean chunkGcInProgress = false;
 
-    ChunkGcManager() {
+    public ChunkGcManager() {
         this.requestFutureChunkGc();
     }
 
@@ -29,7 +33,11 @@ public class ChunkGcManager {
 
         if(!isChunkGcInProgress()){
 
+            Log.debug("Chunk GC is not in progress");
+
             int currentlyLoadedChunks = this.getCurrentlyLoadedChunks();
+
+            Log.debug("Loaded chunks is: "+currentlyLoadedChunks);
 
             ChunkGcCalc.ChunkGCLevel chunkGCLevel = ChunkGcCalc.calcGcLevel(currentlyLoadedChunks);
 
@@ -39,16 +47,30 @@ public class ChunkGcManager {
 
     private int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getAmountOfLoadedChunks(); }
 
-    private void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
+    private synchronized void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
 
-        ChunkGc chunkGcThread = new ChunkGc(chunkGCLevel);
+        Log.debug("Level of chunk gc to be scheduled is: "+chunkGCLevel.getLevelDescription());
 
         int futureTimeSecondsToRunChunkGc = chunkGCLevel.getTimeIntervalBeforeNextAttempt();
 
         Util.futureOneTimeRunInThread(new Callable() {
             @Override
             public void call() {
-                chunkGcThread.performChunkGC();
+
+                Log.debug("Chunk GC time limit has expired");
+
+                //On wakeup, we run a chunk gc immediately based on a ChunkGC level we receive based on the current loaded chunks level
+                ChunkGcCalc.ChunkGCLevel chunkGCLevelForCurrentGc = ChunkGcCalc.calcGcLevel(Globals.world.chunks.getAmountOfLoadedChunks());
+
+                //If the ChunkGcLevel is sleep, we set a delay for the amount of time and simply request another chunkgc on wakeup
+                if(chunkGCLevelForCurrentGc== ChunkGcCalc.ChunkGCLevel.SLEEP){
+                    Log.debug("Chunk GC level is sleep");
+                    Globals.chunkGcManager.scheduleChunkGc(chunkGCLevelForCurrentGc);
+                }else{
+                    ChunkGc chunkGcThread = new ChunkGc(chunkGCLevelForCurrentGc);
+                    Log.debug("Chunk GC level is: "+chunkGCLevelForCurrentGc.getLevelDescription());
+                    chunkGcThread.performChunkGC();
+                }
             }
         }, futureTimeSecondsToRunChunkGc, TimeUnit.SECONDS);
     }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -29,7 +29,7 @@ public class ChunkGcManager {
         return chunkGcInProgress;
     }
 
-    public void requestFutureChunkGc(){
+    public synchronized void requestFutureChunkGc(){
 
         if(!isChunkGcInProgress()){
 
@@ -45,7 +45,7 @@ public class ChunkGcManager {
         }
     }
 
-    private int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getAmountOfLoadedChunks(); }
+    private synchronized int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getAmountOfLoadedChunks(); }
 
     private synchronized void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
 

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -1,24 +1,55 @@
 package org.egordorichev.lasttry.world.chunk.gc;
 import org.egordorichev.lasttry.Globals;
+import org.egordorichev.lasttry.util.Callable;
+import org.egordorichev.lasttry.util.Util;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Responsible for determining intervals between Chunk GC should be run and amount of chunks to be freed.
  *
- * Created by Admin on 05/05/2017.
  */
 public class ChunkGcManager {
 
-    private int currentlyLoadedChunks;
+    boolean chunkGcInProgress = false;
 
-    public void requestGC(){
-
-        currentlyLoadedChunks = Globals.world.chunks.getAmountOfLoadedChunks();
-
-
+    ChunkGcManager() {
+        this.requestFutureChunkGc();
     }
 
+    public synchronized void setChunkGcInProgress(boolean flag) {
+        chunkGcInProgress = flag;
+    }
 
+    public boolean isChunkGcInProgress() {
+        return chunkGcInProgress;
+    }
 
+    public void requestFutureChunkGc(){
 
+        if(!isChunkGcInProgress()){
 
+            int currentlyLoadedChunks = this.getCurrentlyLoadedChunks();
+
+            ChunkGcCalc.ChunkGCLevel chunkGCLevel = ChunkGcCalc.calcGcLevel(currentlyLoadedChunks);
+
+            this.scheduleChunkGc(chunkGCLevel);
+        }
+    }
+
+    private int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getAmountOfLoadedChunks(); }
+
+    private void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
+
+        ChunkGc chunkGcThread = new ChunkGc(chunkGCLevel);
+
+        int futureTimeSecondsToRunChunkGc = chunkGCLevel.getTimeIntervalBeforeNextAttempt();
+
+        Util.futureOneTimeRunInThread(new Callable() {
+            @Override
+            public void call() {
+                chunkGcThread.performChunkGC();
+            }
+        }, futureTimeSecondsToRunChunkGc, TimeUnit.SECONDS);
+    }
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -45,7 +45,7 @@ public class ChunkGcManager {
         }
     }
 
-    private synchronized int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getAmountOfLoadedChunks(); }
+    private synchronized int getCurrentlyLoadedChunks(){ return Globals.world.chunks.getImmutableLoadedChunks().size(); }
 
     private synchronized void scheduleChunkGc(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
 
@@ -60,7 +60,7 @@ public class ChunkGcManager {
                 Log.debug("Chunk GC time limit has expired");
 
                 //On wakeup, we run a chunk gc immediately based on a ChunkGC level we receive based on the current loaded chunks level
-                ChunkGcCalc.ChunkGCLevel chunkGCLevelForCurrentGc = ChunkGcCalc.calcGcLevel(Globals.world.chunks.getAmountOfLoadedChunks());
+                ChunkGcCalc.ChunkGCLevel chunkGCLevelForCurrentGc = ChunkGcCalc.calcGcLevel(Globals.world.chunks.getImmutableLoadedChunks().size());
 
                 //If the ChunkGcLevel is sleep, we set a delay for the amount of time and simply request another chunkgc on wakeup
                 if(chunkGCLevelForCurrentGc== ChunkGcCalc.ChunkGCLevel.SLEEP){

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -1,0 +1,24 @@
+package org.egordorichev.lasttry.world.chunk.gc;
+import org.egordorichev.lasttry.Globals;
+
+/**
+ * Responsible for determining intervals between Chunk GC should be run and amount of chunks to be freed.
+ *
+ * Created by Admin on 05/05/2017.
+ */
+public class ChunkGcManager {
+
+    private int currentlyLoadedChunks;
+
+    public void requestGC(){
+
+        currentlyLoadedChunks = Globals.world.chunks.getAmountOfLoadedChunks();
+
+
+    }
+
+
+
+
+
+}

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
  */
 //todo re-evaluate synchronized methods
 //todo on first run, interval should be set to 10 seconds to allow game to load previous chunks?
+//todo use synchronized block
 public class ChunkGcManager {
 
     boolean chunkGcInProgress = false;
@@ -72,8 +73,6 @@ public class ChunkGcManager {
 
             }
         }, chunkGCLevel.getTimeIntervalBeforeNextAttempt(), TimeUnit.SECONDS);
-
-
     }
 
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -53,6 +53,11 @@ public class ChunkGcManager {
 
         int futureTimeSecondsToRunChunkGc = chunkGCLevel.getTimeIntervalBeforeNextAttempt();
 
+        this.scheduleFutureChunkGcThread(chunkGCLevel);
+    }
+
+    private synchronized void scheduleFutureChunkGcThread(ChunkGcCalc.ChunkGCLevel chunkGCLevel) {
+
         Util.futureOneTimeRunInThread(new Callable() {
             @Override
             public void call() {
@@ -64,10 +69,11 @@ public class ChunkGcManager {
 
                 ChunkGc chunkGcThread = new ChunkGc(chunkGCLevelForCurrentGc);
                 chunkGcThread.onWakeUp();
-                
-            }
-        }, futureTimeSecondsToRunChunkGc, TimeUnit.SECONDS);
-    }
 
+            }
+        }, chunkGCLevel.getTimeIntervalBeforeNextAttempt(), TimeUnit.SECONDS);
+
+
+    }
 
 }

--- a/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
+++ b/core/src/org/egordorichev/lasttry/world/chunk/gc/ChunkGcManager.java
@@ -74,4 +74,6 @@ public class ChunkGcManager {
             }
         }, futureTimeSecondsToRunChunkGc, TimeUnit.SECONDS);
     }
+
+
 }

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -40,10 +40,9 @@ public class WorldChunksComponent extends WorldComponent {
 		}, World.UPDATE_DELAY);
 	}
 
-//todo removed, should it be brought back?
-//	public void update() {
-//
-//	}
+	public void update() {
+
+	}
 
 	public synchronized void updateLogic() {
 		for (int i = 0; i < this.loadedChunks.size(); i++) {
@@ -102,13 +101,14 @@ public class WorldChunksComponent extends WorldComponent {
 		this.chunks[index] = chunk;
 	}
 
-	public boolean isLoaded(int index) {
-		if (!this.isInside(index)) {
-			return false;
-		}
-
-		return this.chunks[index] != null;
-	}
+	//todo is this needed? as we seem to handle null whenever we use chunks
+//	public boolean isLoaded(int index) {
+//		if (!this.isInside(index)) {
+//			return false;
+//		}
+//
+//		return this.chunks[index] != null;
+//	}
 
 	public synchronized Chunk get(int x, int y) {
 		int index = this.getIndex(x, y);

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -12,10 +12,7 @@ import org.egordorichev.lasttry.world.World;
 import org.egordorichev.lasttry.world.chunk.Chunk;
 import org.egordorichev.lasttry.world.chunk.ChunkIO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 
 /**
@@ -169,11 +166,13 @@ public class WorldChunksComponent extends WorldComponent {
 		return x + y * this.world.getWidth() / Chunk.SIZE;
 	}
 
-	//No need to make synchronized, as we are only reading the value.
-	public int getAmountOfLoadedChunks() { return loadedChunks.size(); }
-
 	//todo return immutable object?
-	public ArrayList<Chunk> getLoadedChunks() { return loadedChunks; }
+	public synchronized List<Chunk> getImmutableLoadedChunks() {
+
+		List<Chunk> immutableLoadedChunksList = Collections.unmodifiableList(loadedChunks);
+
+		return immutableLoadedChunksList;
+	}
 
 	public void save() {
 		for (int y = 0; y < Globals.world.getHeight() / Chunk.SIZE; y++) {

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -14,6 +14,7 @@ import org.egordorichev.lasttry.world.chunk.ChunkIO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.UUID;
 
 
@@ -148,17 +149,19 @@ public class WorldChunksComponent extends WorldComponent {
 		loadedChunks.removeIf( loadedChunk -> loadedChunk.getUniqueChunkId().equals(uniqueIdOfChunkToBeRemoved));
 
 		for(int i=0; i<chunks.length; i++){
-			Chunk chunk = chunks[i];
 
-			if(chunk!=null){
-				if(chunk.getUniqueChunkId()==uniqueIdOfChunkToBeRemoved){
-					//Remove reference from list
-					chunks[i]=null;
+			final int index = i;
 
-					//we are only freeing one chunk at a time therefore we can return from the loop after freeing
-					return;
+			Optional<Chunk> optionalChunk = Optional.ofNullable(chunks[i]);
+
+			optionalChunk.ifPresent(chunk -> {
+
+				if(chunk.getUniqueChunkId().equals(uniqueIdOfChunkToBeRemoved)){
+					chunks[index] = null;
 				}
-			}
+
+			});
+			
 		}
 	}
 

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -13,6 +13,8 @@ import org.egordorichev.lasttry.world.chunk.Chunk;
 import org.egordorichev.lasttry.world.chunk.ChunkIO;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
 
 
 /**
@@ -140,12 +142,34 @@ public class WorldChunksComponent extends WorldComponent {
 		return true;
 	}
 
+	//todo may be better to pass entire arraylist, rather than one by one.  Therefore no need to lose and regain monitor continuously?
+	public synchronized void removeChunk(UUID uniqueIdOfChunkToBeRemoved) {
+
+		loadedChunks.removeIf( loadedChunk -> loadedChunk.getUniqueChunkId().equals(uniqueIdOfChunkToBeRemoved));
+
+		for(int i=0; i<chunks.length; i++){
+			Chunk chunk = chunks[i];
+
+			if(chunk!=null){
+				if(chunk.getUniqueChunkId()==uniqueIdOfChunkToBeRemoved){
+					//Remove reference from list
+					chunks[i]=null;
+
+					//we are only freeing one chunk at a time therefore we can return from the loop after freeing
+					return;
+				}
+			}
+		}
+	}
+
 	private int getIndex(int x, int y) {
 		return x + y * this.world.getWidth() / Chunk.SIZE;
 	}
 
 	//No need to make synchronized, as we are only reading the value.
 	public int getAmountOfLoadedChunks() { return loadedChunks.size(); }
+
+	public ArrayList<Chunk> getLoadedChunks() { return loadedChunks; }
 
 	public void save() {
 		for (int y = 0; y < Globals.world.getHeight() / Chunk.SIZE; y++) {

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 
 /**
  * Methods that alter any of the collections that contain Chunks, are synchronized.
- * The ChunkGC thread will alter the Chunk collections (separate from the main thread), when removing unused Chunks.
+ * The ChunkGc thread will alter the Chunk collections (separate from the main thread), when removing unused Chunks.
  * Therefore chunk collection altering methods are made synchronized.
  */
 public class WorldChunksComponent extends WorldComponent {

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -12,6 +12,7 @@ import org.egordorichev.lasttry.world.World;
 import org.egordorichev.lasttry.world.chunk.Chunk;
 import org.egordorichev.lasttry.world.chunk.ChunkIO;
 
+import javax.swing.text.html.Option;
 import java.util.*;
 
 
@@ -39,9 +40,10 @@ public class WorldChunksComponent extends WorldComponent {
 		}, World.UPDATE_DELAY);
 	}
 
-	public void update() {
-
-	}
+//todo removed, should it be brought back?
+//	public void update() {
+//
+//	}
 
 	public synchronized void updateLogic() {
 		for (int i = 0; i < this.loadedChunks.size(); i++) {
@@ -147,19 +149,23 @@ public class WorldChunksComponent extends WorldComponent {
 
 		for(int i=0; i<chunks.length; i++){
 
-			final int index = i;
-
 			Optional<Chunk> optionalChunk = Optional.ofNullable(chunks[i]);
 
-			optionalChunk.ifPresent(chunk -> {
-
-				if(chunk.getUniqueChunkId().equals(uniqueIdOfChunkToBeRemoved)){
-					chunks[index] = null;
-				}
-
-			});
+			removeChunkInChunksArray(i,optionalChunk, uniqueIdOfChunkToBeRemoved );
 			
 		}
+	}
+
+	private synchronized void removeChunkInChunksArray(final int index, Optional<Chunk> optionalChunk, UUID uniqueIdOfChunkToBeRemoved) {
+
+		optionalChunk.ifPresent(chunk -> {
+
+			if(chunk.getUniqueChunkId().equals(uniqueIdOfChunkToBeRemoved)){
+				chunks[index] = null;
+			}
+
+		});
+
 	}
 
 	private int getIndex(int x, int y) {

--- a/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
+++ b/core/src/org/egordorichev/lasttry/world/components/WorldChunksComponent.java
@@ -169,6 +169,7 @@ public class WorldChunksComponent extends WorldComponent {
 	//No need to make synchronized, as we are only reading the value.
 	public int getAmountOfLoadedChunks() { return loadedChunks.size(); }
 
+	//todo return immutable object?
 	public ArrayList<Chunk> getLoadedChunks() { return loadedChunks; }
 
 	public void save() {


### PR DESCRIPTION
Automatically removes the oldest Chunk in the game memory.
Retrieves amount of loaded chunks.
Calculates a percentage based on the amount of loaded chunks & the max amount of chunks in the game world.
If total chunks is 50 and amount of loaded chunks is 25, 50% of chunks are full.
Based on this percentage, a scheduled task is generated:
If 75% of chunks are full, next chunk GC will be in 30 seconds and will remove 10 chunks.
If 15-25% chunks are full, next chunk GC will be in 120 seconds and will remove 5 chunks.

I had to balance between high frequency of chunk GC calls and amount of chunks to remove per GC call.
For example:
The max amount of chunks on a large map is approximately 288 chunks.  
If the amount of chunks is 80% full, then proceeding to remove 50 chunks in one chunk GC call could potentially result in a noticeable game pause.

Please let me know if I took the right approach or if there is a better way this could be done?  Please also let me know on any improvements that can be made?

The potential next step, would be to implement a check so that ONLY chunks that have not been accessed in the last 'x' seconds/minutes are eligible for removal.  Please let me know, what you think?

Thanks
 